### PR TITLE
Remove slash from router prefix

### DIFF
--- a/client/src/elm/App/Router.elm
+++ b/client/src/elm/App/Router.elm
@@ -14,19 +14,19 @@ delta2url previous current =
             Nothing
 
         Login ->
-            Just <| UrlChange NewEntry "/#login"
+            Just <| UrlChange NewEntry "#login"
 
         MyAccount ->
-            Just <| UrlChange NewEntry "/#my-account"
+            Just <| UrlChange NewEntry "#my-account"
 
         PageNotFound ->
-            Just <| UrlChange NewEntry "/#404"
+            Just <| UrlChange NewEntry "#404"
 
         Item id ->
-            Just <| UrlChange NewEntry ("/#item/" ++ id)
+            Just <| UrlChange NewEntry ("#item/" ++ id)
 
         Dashboard ->
-            Just <| UrlChange NewEntry "/#"
+            Just <| UrlChange NewEntry ""
 
 
 location2messages : Location -> List Msg

--- a/client/src/elm/App/Router.elm
+++ b/client/src/elm/App/Router.elm
@@ -26,7 +26,8 @@ delta2url previous current =
             Just <| UrlChange NewEntry ("#item/" ++ id)
 
         Dashboard ->
-            Just <| UrlChange NewEntry ""
+            -- Hack to allow dashboard to change the URL.
+            Just <| UrlChange NewEntry "# "
 
 
 location2messages : Location -> List Msg


### PR DESCRIPTION
So it can also work on URLs with subdirectories, for example https://example.com/app.