### PR TITLE
WIP - Pusher events into Elm

### DIFF
--- a/client/src/elm/App/Update.elm
+++ b/client/src/elm/App/Update.elm
@@ -10,6 +10,7 @@ import ItemManager.Update
 import Json.Decode exposing (decodeValue, bool)
 import Json.Encode exposing (Value)
 import Pages.Login.Update
+import Pusher.Model exposing (PusherConfig, pusherEvents)
 import RemoteData exposing (RemoteData(..), WebData)
 import Task
 import Time exposing (minute)
@@ -24,7 +25,7 @@ init flags =
                 Just config ->
                     let
                         defaultCmds =
-                            [ pusherKey config.pusherKey
+                            [ pusherConfig <| PusherConfig config.pusherKey pusherEvents
                             , Task.perform SetCurrentDate Date.now
                             ]
 
@@ -224,9 +225,9 @@ subscriptions model =
 port accessTokenPort : String -> Cmd msg
 
 
-{-| Send Pusher key to JS.
+{-| Send Pusher configuration (key and events) to JS.
 -}
-port pusherKey : String -> Cmd msg
+port pusherConfig : PusherConfig -> Cmd msg
 
 
 {-| Get a singal if internet connection is lost.

--- a/client/src/elm/Pusher/Model.elm
+++ b/client/src/elm/Pusher/Model.elm
@@ -9,5 +9,21 @@ type alias PusherEvent =
     }
 
 
+type alias PusherConfig =
+    { key : String
+    , events : List PusherEventType
+    }
+
+
+type alias PusherEventType =
+    String
+
+
 type PusherEventData
     = ItemUpdate Item
+
+
+pusherEvents : List PusherEventType
+pusherEvents =
+    [ "item__update"
+    ]

--- a/client/src/elm/Pusher/Model.elm
+++ b/client/src/elm/Pusher/Model.elm
@@ -11,19 +11,19 @@ type alias PusherEvent =
 
 type alias PusherConfig =
     { key : String
-    , events : List PusherEventType
+    , events : List String
     }
 
 
-type alias PusherEventType =
-    String
+type PusherEventType
+    = ItemUpdate
 
 
 type PusherEventData
     = ItemUpdate Item
 
 
-pusherEvents : List PusherEventType
+pusherEvents : List String
 pusherEvents =
     [ "item__update"
     ]

--- a/client/src/elm/Pusher/Utils.elm
+++ b/client/src/elm/Pusher/Utils.elm
@@ -1,0 +1,8 @@
+module Pusher.Utils exposing (getEventNameFromType)
+
+import Pusher.Model exposing (PusherEventType)
+
+
+getEventNameFromType : PusherEventType -> String
+getEventNameFromType eventType =
+    toString eventType

--- a/client/src/js/app.js
+++ b/client/src/js/app.js
@@ -8,8 +8,9 @@ elmApp.ports.accessTokenPort.subscribe(function(accessToken) {
 });
 
 
-elmApp.ports.pusherKey.subscribe(function(appKey) {
-  var pusher = new Pusher(appKey, {
+elmApp.ports.pusherConfig.subscribe(function(config) {
+  console.log(config);
+  var pusher = new Pusher(config.key, {
     cluster: 'eu'
   });
 
@@ -18,9 +19,7 @@ elmApp.ports.pusherKey.subscribe(function(appKey) {
   if (!pusher.channel(channelName)) {
       var channel = pusher.subscribe(channelName);
 
-      var eventNames = [
-        'item__update',
-      ];
+      var eventNames = config.events;
 
       eventNames.forEach(function(eventName) {
         channel.bind(eventName, function (data) {


### PR DESCRIPTION
Moves the list of Pusher events into the pusher port, so it is handled on the Elm side.

Will fix #12 

![anim](https://cloud.githubusercontent.com/assets/877002/21937743/b873f1d0-d9b8-11e6-97ba-c91cc623098e.gif)
