### PR TITLE
Revert "Use Bower for Semantic ui"

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -12,7 +12,6 @@
   ],
   "dependencies": {
     "copy-button": "sudodoki/copy-button#2.0.0",
-    "offline": "0.7.18",
-    "semantic": "semantic-ui#2.2.7"
+    "offline": "0.7.18"
   }
 }

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Elm</title>
-  <link rel="stylesheet" href="bower_components/semantic/dist/semantic.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/semantic-ui/2.2.6/semantic.min.css">
   <script src="bower_components/copy-button/bundled.min.js"></script>
   <script src="bower_components/offline/offline.min.js"></script>
 


### PR DESCRIPTION
Reverts Gizra/drupal-elm-starter#24

This is causing problems with `gulp publish`, so it will require some more work.