### PR TITLE
Fix use of browser history

### DIFF
--- a/client/src/elm/App/Router.elm
+++ b/client/src/elm/App/Router.elm
@@ -14,20 +14,30 @@ delta2url previous current =
             Nothing
 
         Login ->
-            Just <| UrlChange NewEntry "#login"
+            Just <| UrlChange NewEntry "#/login"
 
         MyAccount ->
-            Just <| UrlChange NewEntry "#my-account"
+            Just <| UrlChange NewEntry "#/my-account"
 
         PageNotFound ->
-            Just <| UrlChange NewEntry "#404"
+            Just <| UrlChange NewEntry "#/404"
 
         Item id ->
-            Just <| UrlChange NewEntry ("#item/" ++ id)
+            Just <| UrlChange NewEntry ("#/item/" ++ id)
 
         Dashboard ->
-            -- Hack to allow dashboard to change the URL.
-            Just <| UrlChange NewEntry "# "
+            Just <|
+                -- We treat this as the default URL, so you can get here from
+                -- two mappings. So, check whether we were already on the
+                -- Dashboard. If so, just update the URL without creating a new
+                -- history entry. (Usually, you don't need to deal with this,
+                -- since elm-route-url wil filter out identical URLs).
+                case previous.activePage of
+                    Dashboard ->
+                        UrlChange ModifyEntry "#/"
+
+                    _ ->
+                        UrlChange NewEntry "#/"
 
 
 location2messages : Location -> List Msg

--- a/client/src/elm/Pages/Items/View.elm
+++ b/client/src/elm/Pages/Items/View.elm
@@ -74,7 +74,10 @@ config =
                 , viewData =
                     \( itemId, item ) ->
                         Table.HtmlDetails []
-                            [ a [ href "#", onClick <| SetRedirectPage <| App.PageType.Item itemId ]
+                            [ a
+                                [ onClick <| SetRedirectPage <| App.PageType.Item itemId
+                                , style [ ( "cursor", "pointer" ) ]
+                                ]
                                 [ text item.name ]
                             ]
                 , sorter = Table.increasingOrDecreasingBy <| Tuple.second >> .name


### PR DESCRIPTION
This will fix #38.

One problem was the `a [href "#"] [onClick ...]` ... the `href` essentially contradicts what the `onClick` wants to do. One would either have to use the correct `href` (and have no `onClick`), or (better) have no `href` and just rely on the `onClick`.

I'm presuming the purpose of the `href "#"` is to ensure that the cursor changes to a pointer, so I put that in manually.

I suppose we do lose the ":visited" styling this way (which we could get by using the correct `href`) -- in cases where distinct styling for ":visited" was critical, one could use the correct `href` and leave off the `onClick`.

The other issue relates to how to handle "default" URLs (that is, what page do we want to show for an empty hash). I've made some changes here that seem to improve that. I should work on this a bit and see if I can make it nicer in `elm-route-url` -- there is some interaction here between what `elm-lang/navigation` does and and what `elm-route-url` does and what `evancz/url-parser` does, and I'm not absolutely sure what the best approach is.