### PR TITLE
Add bundle exec to jekyll commands to enforce version.

### DIFF
--- a/static/gulpfile.js
+++ b/static/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task("clean:prod", del.bind(null, ["site"]));
 
 // Runs the build command for Jekyll to compile the site locally
 // This will build the site with the production settings
-gulp.task("jekyll:dev", $.shell.task("jekyll build"));
+gulp.task("jekyll:dev", $.shell.task("bundle exec jekyll build"));
 gulp.task("jekyll-rebuild", ["jekyll:dev", "js"], function () {
   reload;
 });
@@ -37,7 +37,7 @@ gulp.task("jekyll-rebuild", ["jekyll:dev", "js"], function () {
 // Almost identical to the above task, but instead we load in the build configuration
 // that overwrites some of the settings in the regular configuration so that you
 // don"t end up publishing your drafts or future posts
-gulp.task("jekyll:prod", $.shell.task("jekyll build --config _config.yml,_config.build.yml"));
+gulp.task("jekyll:prod", $.shell.task("bundle exec jekyll build --config _config.yml,_config.build.yml"));
 
 // Compiles the SASS files and moves them into the "assets/stylesheets" directory
 gulp.task("styles", function () {
@@ -159,7 +159,7 @@ gulp.task("jslint", function () {
 
 // Runs "jekyll doctor" on your site to check for errors with your configuration
 // and will check for URL errors a well
-gulp.task("doctor", $.shell.task("jekyll doctor"));
+gulp.task("doctor", $.shell.task("bundle exec jekyll doctor"));
 
 // BrowserSync will serve our site on a local server for us and other devices to use
 // It will also autoreload across all devices as well as keep the viewport synchronized


### PR DESCRIPTION
Per issue in [Gizra-SUI](https://github.com/Gizra/gizra-sui/pull/36#issuecomment-279136837) to ensure proper jekyll version is used on gulp command.