### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+client/node_modules
+client/serve
+client/dist
+client/elm-stuff
+client/bower_components
+server/www


### PR DESCRIPTION
To make sure you are able to simultaneously use your local instance and build clean Docker images, without copying all the built material into Docker.