### PR TITLE
Config/View.elm: typo fix and update the reference to the configfile

### DIFF
--- a/client/src/elm/Config/View.elm
+++ b/client/src/elm/Config/View.elm
@@ -12,5 +12,5 @@ view =
     div
         [ class "config-error" ]
         [ h2 [] [ text "Configuration error" ]
-        , div [] [ text "Check your LocalConfig.elm file and make sure you have defined the environment properly" ]
+        , div [] [ text "Check your LocalConfig.elm or Config.elm file and make sure you have defined the environment properly" ]
         ]

--- a/client/src/elm/Config/View.elm
+++ b/client/src/elm/Config/View.elm
@@ -12,5 +12,5 @@ view =
     div
         [ class "config-error" ]
         [ h2 [] [ text "Configuration error" ]
-        , div [] [ text "Check your Config.elm file and make sure you have defined the enviorement properly" ]
+        , div [] [ text "Check your LocalConfig.elm file and make sure you have defined the environment properly" ]
         ]


### PR DESCRIPTION
![msg](https://cloud.githubusercontent.com/assets/114076/23796269/598794c0-059a-11e7-9156-502b5db0a01d.png)

Now we have `LocalConfig.elm`, it seems `Config.elm` is not for messing around.