### PR TITLE
Docker-compose invocation: any non-null exit status is an error

### DIFF
--- a/ci-scripts/test_server.sh
+++ b/ci-scripts/test_server.sh
@@ -25,7 +25,8 @@ docker-compose up --abort-on-container-exit
 # containers failed, we need to inspect it like this.
 # from http://blog.ministryofprogramming.com/docker-compose-and-exit-codes/
 docker-compose --file=docker-compose.yml ps -q | xargs docker inspect -f '{{ .State.ExitCode }}' | while read code; do
-  if [ "$code" = "1" ]; then
-    exit 1
+  if [ ! "$code" = "0" ]; then
+    exit $code
   fi
 done
+exit 0


### PR DESCRIPTION
If docker-compose container stops with a non-1, non-0 exit code, we treat it as success right now, it should not be the case.