### PR TITLE
.travis.yml: temporarily allow client failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ language: php
 php:
   - 5.6
 
+matrix:
+  allow_failures:
+    - php: 5.6
+      env: BUILD_CLIENT=1
+
 env:
   - BUILD_SERVER=1
   - BUILD_CLIENT=1
@@ -16,10 +21,6 @@ env:
 
 services:
   - docker
-
-cache:
-  directories:
-    - sysconfcpus
 
 before_install:
   - composer self-update


### PR DESCRIPTION
Due to network issues related to Node.js