### PR TITLE
WDIO test failure summary

### DIFF
--- a/ci-scripts/docker_files/run_webdriverio.sh
+++ b/ci-scripts/docker_files/run_webdriverio.sh
@@ -13,12 +13,10 @@ print_message "Test WebDriverIO."
 cd $ROOT_DIR/client
 
 WDIO_ALL_RET=0
+declare -a WDIO_FAILED_SPECS
 set +o errexit
 for SPEC in test/specs/*js; do
-  echo "---------"
-  echo "Executing $SPEC"
-  echo "---------"
-  echo ""
+  print_message "Executing $SPEC"
   WDIO_RET=0
   for i in `seq 3`; do
     ./node_modules/.bin/wdio wdio.conf.travis.js --spec $SPEC
@@ -28,20 +26,27 @@ for SPEC in test/specs/*js; do
       # but of course we quit on first success
       break
     fi
-    echo "$SPEC failed for the attempt ($i.), retrying..."
+    print_error_message "$SPEC failed for the attempt ($i.), retrying..."
   done
   if [[ $WDIO_RET -ne 0 ]]; then
-    echo "$SPEC failed"
+    print_error_message "$SPEC failed"
     WDIO_ALL_RET=$WDIO_RET
+    WDIO_FAILED_SPECS+=($SPEC)
   fi
 done
 
 # If WDIO failed, check Watchdog and check if we can access the backend.
 if [[ $WDIO_ALL_RET -ne 0 ]]; then
+  print_error_message "There are at least one failing specs. See debug details and list below"
   cd $ROOT_DIR/server/www
   export PATH="$HOME/.composer/vendor/bin:$PATH"
   drush cc drush
   drush watchdog-show
   curl -D - http://server.local/
+  print_error_message "List of failed specs"
+  for SPEC in $WDIO_FAILED_SPECS
+  do
+    print_error_message $SPEC
+  done;
 fi
 exit $WDIO_ALL_RET


### PR DESCRIPTION
# Current status
![output](https://cloud.githubusercontent.com/assets/114076/24194143/3f7a5694-0ef5-11e7-9959-3f152a0fc1b1.png)

Of course at this PR, at Travis, the expected thing is to not see this new behavior :)

# How to test
* Stop/do not start selenium server
* Edit `ci-scripts/docker_files/helper_functions.sh` with proper root dir temporarily (beware of not committing it)
* `bash run_webdriverio.sh` from the containing directory

#79 