### PR TITLE
prepare_client.sh: ShellCheck fix

### DIFF
--- a/ci-scripts/prepare_client.sh
+++ b/ci-scripts/prepare_client.sh
@@ -12,5 +12,5 @@ if [ -z "${BUILD_CLIENT+x}" ] || [ "$BUILD_CLIENT" -ne 1 ]; then
  exit 0;
 fi
 
-$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make --yes
+"$TRAVIS_BUILD_DIR"/sysconfcpus/bin/sysconfcpus -n 2 elm-make --yes
 cp ./client/src/elm/LocalConfig.Example.elm ./client/src/elm/LocalConfig.elm


### PR DESCRIPTION
```
$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make --yes
^-- SC2086: Double quote to prevent globbing and word splitting.
```

Fixed this warning.

Will fix #98 