### PR TITLE
Video failure detection

### DIFF
--- a/ci-scripts/test_server.sh
+++ b/ci-scripts/test_server.sh
@@ -29,7 +29,7 @@ cd ci-scripts/docker_files
 # Docker-compose up won't return with non-zero exit code if one of the
 # containers failed, we need to inspect it like this.
 # from http://blog.ministryofprogramming.com/docker-compose-and-exit-codes/
-docker-compose --file=docker-compose.yml ps -q | xargs docker inspect -f '{{ .State.ExitCode }}' | while read code; do
+docker-compose --file=docker-compose.yml ps -q server.local | xargs docker inspect -f '{{ .State.ExitCode }}' | while read code; do
   if [ ! "$code" = "0" ]; then
     source "$TRAVIS_BUILD_DIR"/server/travis.config.sh
     sudo chmod -R 777 /tmp/test_results


### PR DESCRIPTION
We should only check the main container's exit status, otherwise Selenium-related containers might trigger the video upload.