### PR TITLE
WIP: Allow the user to edit the name of an item

### DIFF
--- a/client/src/elm/Item/Encoder.elm
+++ b/client/src/elm/Item/Encoder.elm
@@ -1,9 +1,9 @@
-module Item.Encoder exposing (encodeItemTitle)
+module Item.Encoder exposing (encodeItemTitlePatch)
 
 import Json.Encode exposing (Value, object, string)
 import Item.Model exposing (Item)
 
 
-encodeItemTitle : Item -> Value
-encodeItemTitle item =
+encodeItemTitlePatch : Item -> Value
+encodeItemTitlePatch item =
     object [ ( "label", string item.name ) ]

--- a/client/src/elm/Item/Encoder.elm
+++ b/client/src/elm/Item/Encoder.elm
@@ -1,0 +1,9 @@
+module Item.Encoder exposing (encodeItemTitle)
+
+import Json.Encode exposing (Value, object, string)
+import Item.Model exposing (Item)
+
+
+encodeItemTitle : Item -> Value
+encodeItemTitle item =
+    object [ ( "label", string item.name ) ]

--- a/client/src/elm/Item/Encoder.elm
+++ b/client/src/elm/Item/Encoder.elm
@@ -1,9 +1,12 @@
-module Item.Encoder exposing (encodeItemTitlePatch)
+module Item.Encoder exposing (encodeItemName)
 
 import Json.Encode exposing (Value, object, string)
 import Item.Model exposing (Item)
 
 
-encodeItemTitlePatch : Item -> Value
-encodeItemTitlePatch item =
+{-| Encode just the name of the item, so we can send a
+PATCH request to update the name on the backend.
+-}
+encodeItemName : Item -> Value
+encodeItemName item =
     object [ ( "label", string item.name ) ]

--- a/client/src/elm/ItemManager/Model.elm
+++ b/client/src/elm/ItemManager/Model.elm
@@ -23,6 +23,7 @@ just stay within the `WebData` container.
 -}
 type alias Model =
     { items : Dict ItemId (WebData Item)
+    , itemPage : Pages.Item.Model.Model
     , itemsPage : Pages.Items.Model.Model
     }
 
@@ -49,5 +50,6 @@ type Msg
 emptyModel : Model
 emptyModel =
     { items = Dict.empty
+    , itemPage = Pages.Item.Model.emptyModel
     , itemsPage = Pages.Items.Model.emptyModel
     }

--- a/client/src/elm/ItemManager/Model.elm
+++ b/client/src/elm/ItemManager/Model.elm
@@ -44,6 +44,7 @@ type Msg
     | MsgPagesItems Pages.Items.Model.Msg
     | HandleFetchedItem ItemId (Result Http.Error Item)
     | HandleFetchedItems (Result Http.Error ItemsDict)
+    | HandlePatchResponse (Result Http.Error ())
     | HandlePusherEvent (Result String PusherEvent)
 
 

--- a/client/src/elm/ItemManager/Update.elm
+++ b/client/src/elm/ItemManager/Update.elm
@@ -5,7 +5,7 @@ import Config.Model exposing (BackendUrl)
 import Date exposing (Date)
 import Dict exposing (Dict)
 import Item.Model exposing (Item, ItemId)
-import Item.Encoder exposing (encodeItemTitlePatch)
+import Item.Encoder exposing (encodeItemName)
 import ItemManager.Decoder exposing (decodeItemFromResponse, decodeItemsFromResponse)
 import ItemManager.Model exposing (..)
 import ItemManager.Utils exposing (..)
@@ -224,7 +224,7 @@ sendUpdatedItemToBackend backendUrl accessToken itemId item =
         command =
             HttpBuilder.patch (backendUrl ++ "/api/items/" ++ itemId)
                 |> withQueryParams [ ( "access_token", accessToken ) ]
-                |> withJsonBody (encodeItemTitlePatch item)
+                |> withJsonBody (encodeItemName item)
                 |> send HandlePatchResponse
     in
         command

--- a/client/src/elm/ItemManager/Update.elm
+++ b/client/src/elm/ItemManager/Update.elm
@@ -70,10 +70,13 @@ update currentDate backendUrl accessToken user msg model =
             case getItem id model of
                 Success item ->
                     let
-                        ( subModel, subCmd, redirectPage ) =
-                            Pages.Item.Update.update backendUrl accessToken user subMsg item
+                        ( subModel, item_, subCmd, redirectPage ) =
+                            Pages.Item.Update.update backendUrl accessToken user subMsg item model.itemPage
                     in
-                        ( { model | items = Dict.insert id (Success subModel) model.items }
+                        ( { model
+                            | items = Dict.insert id (Success item_) model.items
+                            , itemPage = subModel
+                          }
                         , Cmd.map (MsgPagesItem id) subCmd
                         , redirectPage
                         )

--- a/client/src/elm/ItemManager/View.elm
+++ b/client/src/elm/ItemManager/View.elm
@@ -59,4 +59,4 @@ viewPageItem currentDate id user model =
 
         Success item ->
             div []
-                [ Html.map (MsgPagesItem id) <| Pages.Item.View.view currentDate user id item ]
+                [ Html.map (MsgPagesItem id) <| Pages.Item.View.view currentDate user id item model.itemPage ]

--- a/client/src/elm/Pages/Item/Model.elm
+++ b/client/src/elm/Pages/Item/Model.elm
@@ -1,6 +1,7 @@
 module Pages.Item.Model exposing (..)
 
 import App.PageType exposing (Page(..))
+import Item.Model exposing (Item)
 import Pusher.Model exposing (PusherEventData)
 
 

--- a/client/src/elm/Pages/Item/Model.elm
+++ b/client/src/elm/Pages/Item/Model.elm
@@ -1,7 +1,4 @@
-module Pages.Item.Model
-    exposing
-        ( Msg(..)
-        )
+module Pages.Item.Model exposing (..)
 
 import App.PageType exposing (Page(..))
 import Pusher.Model exposing (PusherEventData)
@@ -10,3 +7,12 @@ import Pusher.Model exposing (PusherEventData)
 type Msg
     = HandlePusherEventData PusherEventData
     | SetRedirectPage Page
+
+
+type alias Model =
+    {}
+
+
+emptyModel : Model
+emptyModel =
+    {}

--- a/client/src/elm/Pages/Item/Model.elm
+++ b/client/src/elm/Pages/Item/Model.elm
@@ -19,7 +19,7 @@ we're returning from `Pages.Item.Update.update` to the
 ItemManager. If the user changed it, then we should send the
 updated item to the server; if, on the other hand, we got
 this change from the server in the first place, all we have to
-is make a note of it ourselves.
+do is make a note of it ourselves.
 -}
 type ItemUpdate
     = UpdateFromBackend Item

--- a/client/src/elm/Pages/Item/Model.elm
+++ b/client/src/elm/Pages/Item/Model.elm
@@ -13,6 +13,43 @@ type Msg
     | EditingNameCancel
 
 
+{-| This lets us keep track of who has updated the item that
+we're returning from `Pages.Item.Update.update` to the
+ItemManager. If the user changed it, then we should send the
+updated item to the server; if, on the other hand, we got
+this change from the server in the first place, all we have to
+is make a note of it ourselves.
+-}
+type ItemUpdate
+    = UpdateFromBackend Item
+    | UpdateFromUser Item
+    | NoUpdate
+
+
+{-| This allows you to easily do something with the updated
+item if there is one, wherever you got it from. Cf.
+`Maybe.Extra.unwrap`.
+-}
+unwrapItemUpdate : a -> (Item -> a) -> ItemUpdate -> a
+unwrapItemUpdate default f itemUpdate =
+    case itemUpdate of
+        UpdateFromBackend item ->
+            f item
+
+        UpdateFromUser item ->
+            f item
+
+        NoUpdate ->
+            default
+
+
+{-| At the moment the only state peculiar to the Item page is
+whether the user is currently editing the name of the item,
+and if so, what have they typed in. (We wouldn't have to keep
+track of the latter in the Model, but doing so allows us to
+the contents of the input field if the users navigates to
+another page and then comes back.)
+-}
 type alias Model =
     { editingItemName : Maybe String }
 

--- a/client/src/elm/Pages/Item/Model.elm
+++ b/client/src/elm/Pages/Item/Model.elm
@@ -7,12 +7,16 @@ import Pusher.Model exposing (PusherEventData)
 type Msg
     = HandlePusherEventData PusherEventData
     | SetRedirectPage Page
+    | EditingNameBegin
+    | EditingNameUpdate String
+    | EditingNameFinish
+    | EditingNameCancel
 
 
 type alias Model =
-    {}
+    { editingItemName : Maybe String }
 
 
 emptyModel : Model
 emptyModel =
-    {}
+    { editingItemName = Nothing }

--- a/client/src/elm/Pages/Item/Update.elm
+++ b/client/src/elm/Pages/Item/Update.elm
@@ -4,8 +4,7 @@ import App.PageType exposing (Page(..))
 import Config.Model exposing (BackendUrl)
 import Item.Model exposing (Item)
 import User.Model exposing (..)
-import Pages.Item.Model exposing (Msg(..))
-import Pages.Item.Model exposing (Model)
+import Pages.Item.Model exposing (Model, Msg(..))
 import Pusher.Model exposing (PusherEventData(..))
 
 
@@ -27,3 +26,42 @@ update backendUrl accessToken user msg item model =
 
         SetRedirectPage page ->
             ( model, item, Cmd.none, Just page )
+
+        EditingNameBegin ->
+            ( { model | editingItemName = Just item.name }
+            , item
+            , Cmd.none
+            , Nothing
+            )
+
+        EditingNameFinish ->
+            let
+                newName =
+                    case model.editingItemName of
+                        Just name ->
+                            name
+
+                        Nothing ->
+                            -- this case shouldn't be
+                            -- possible!
+                            item.name
+            in
+                ( { model | editingItemName = Nothing }
+                , { item | name = newName }
+                , Cmd.none
+                , Nothing
+                )
+
+        EditingNameUpdate updatedName ->
+            ( { model | editingItemName = Just updatedName }
+            , item
+            , Cmd.none
+            , Nothing
+            )
+
+        EditingNameCancel ->
+            ( { model | editingItemName = Nothing }
+            , item
+            , Cmd.none
+            , Nothing
+            )

--- a/client/src/elm/Pages/Item/Update.elm
+++ b/client/src/elm/Pages/Item/Update.elm
@@ -2,14 +2,15 @@ module Pages.Item.Update exposing (update)
 
 import App.PageType exposing (Page(..))
 import Config.Model exposing (BackendUrl)
+import Item.Model exposing (Item)
 import User.Model exposing (..)
 import Pages.Item.Model exposing (Msg(..))
+import Pages.Item.Model exposing (Model)
 import Pusher.Model exposing (PusherEventData(..))
-import Item.Model exposing (Item)
 
 
-update : BackendUrl -> String -> User -> Msg -> Item -> ( Item, Cmd Msg, Maybe Page )
-update backendUrl accessToken user msg item =
+update : BackendUrl -> String -> User -> Msg -> Item -> Model -> ( Model, Item, Cmd Msg, Maybe Page )
+update backendUrl accessToken user msg item model =
     case msg of
         HandlePusherEventData event ->
             case event of
@@ -18,10 +19,11 @@ update backendUrl accessToken user msg item =
                     -- which has already been saved at the server. Note that
                     -- we may have just pushed this change ourselves, so it's
                     -- already reflected here.
-                    ( newItem
+                    ( model
+                    , newItem
                     , Cmd.none
                     , Nothing
                     )
 
         SetRedirectPage page ->
-            ( item, Cmd.none, Just page )
+            ( model, item, Cmd.none, Just page )

--- a/client/src/elm/Pages/Item/Update.elm
+++ b/client/src/elm/Pages/Item/Update.elm
@@ -4,11 +4,11 @@ import App.PageType exposing (Page(..))
 import Config.Model exposing (BackendUrl)
 import Item.Model exposing (Item)
 import User.Model exposing (..)
-import Pages.Item.Model exposing (Model, Msg(..))
+import Pages.Item.Model exposing (Model, Msg(..), ItemUpdate(..))
 import Pusher.Model exposing (PusherEventData(..))
 
 
-update : BackendUrl -> String -> User -> Msg -> Item -> Model -> ( Model, Item, Cmd Msg, Maybe Page )
+update : BackendUrl -> String -> User -> Msg -> Item -> Model -> ( Model, ItemUpdate, Cmd Msg, Maybe Page )
 update backendUrl accessToken user msg item model =
     case msg of
         HandlePusherEventData event ->
@@ -19,17 +19,17 @@ update backendUrl accessToken user msg item model =
                     -- we may have just pushed this change ourselves, so it's
                     -- already reflected here.
                     ( model
-                    , newItem
+                    , UpdateFromBackend newItem
                     , Cmd.none
                     , Nothing
                     )
 
         SetRedirectPage page ->
-            ( model, item, Cmd.none, Just page )
+            ( model, NoUpdate, Cmd.none, Just page )
 
         EditingNameBegin ->
             ( { model | editingItemName = Just item.name }
-            , item
+            , NoUpdate
             , Cmd.none
             , Nothing
             )
@@ -49,21 +49,21 @@ update backendUrl accessToken user msg item model =
                             item.name
             in
                 ( { model | editingItemName = Nothing }
-                , { item | name = newName }
+                , UpdateFromUser { item | name = newName }
                 , Cmd.none
                 , Nothing
                 )
 
         EditingNameUpdate updatedName ->
             ( { model | editingItemName = Just updatedName }
-            , item
+            , NoUpdate
             , Cmd.none
             , Nothing
             )
 
         EditingNameCancel ->
             ( { model | editingItemName = Nothing }
-            , item
+            , NoUpdate
             , Cmd.none
             , Nothing
             )

--- a/client/src/elm/Pages/Item/Update.elm
+++ b/client/src/elm/Pages/Item/Update.elm
@@ -42,8 +42,10 @@ update backendUrl accessToken user msg item model =
                             name
 
                         Nothing ->
-                            -- this case shouldn't be
-                            -- possible!
+                            -- if this happens, then the view
+                            -- code is broken. We can't
+                            -- finish editing the name unless
+                            -- we've already started!
                             item.name
             in
                 ( { model | editingItemName = Nothing }

--- a/client/src/elm/Pages/Item/View.elm
+++ b/client/src/elm/Pages/Item/View.elm
@@ -3,6 +3,8 @@ module Pages.Item.View exposing (view)
 import Date exposing (Date)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick, on, targetValue)
+import Json.Decode
 import Pages.Item.Model exposing (Model, Msg(..))
 import Item.Model exposing (ItemId, Item)
 import User.Model exposing (User)
@@ -13,16 +15,15 @@ view currentDate currentUser itemId item model =
     div []
         [ div
             [ class "ui secondary pointing fluid menu" ]
-            [ h2
-                [ class "ui header" ]
-                [ text item.name ]
-            , div
-                [ class "right menu" ]
-                [ a
-                    [ class "ui active item" ]
-                    [ text "Overview" ]
-                ]
-            ]
+          <|
+            itemHeader item model
+                ++ [ div
+                        [ class "right menu" ]
+                        [ a
+                            [ class "ui active item" ]
+                            [ text "Overview" ]
+                        ]
+                   ]
         , div []
             [ img [ src item.image, alt item.name ] []
             ]
@@ -30,3 +31,48 @@ view currentDate currentUser itemId item model =
             [ class "ui divider" ]
             []
         ]
+
+
+itemHeader : Item -> Model -> List (Html Msg)
+itemHeader item model =
+    case model.editingItemName of
+        Just editedName ->
+            [ div
+                [ class "ui header input" ]
+                [ h2 []
+                    [ input
+                        [ value editedName
+                        , onChange EditingNameUpdate
+                        ]
+                        []
+                    ]
+                , button
+                    [ name "Done"
+                    , type_ "button"
+                    , onClick EditingNameFinish
+                    ]
+                    [ text "Done" ]
+                , button
+                    [ name "Cancel"
+                    , type_ "button"
+                    , onClick EditingNameCancel
+                    ]
+                    [ text "Cancel" ]
+                ]
+            ]
+
+        Nothing ->
+            [ h2
+                [ class "ui header" ]
+                [ text item.name ]
+            , button
+                [ onClick EditingNameBegin
+                , class "icon edit"
+                ]
+                []
+            ]
+
+
+onChange : (String -> Msg) -> Attribute Msg
+onChange tagger =
+    on "change" (Json.Decode.map tagger targetValue)

--- a/client/src/elm/Pages/Item/View.elm
+++ b/client/src/elm/Pages/Item/View.elm
@@ -3,13 +3,13 @@ module Pages.Item.View exposing (view)
 import Date exposing (Date)
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Pages.Item.Model exposing (Msg(..))
+import Pages.Item.Model exposing (Model, Msg(..))
 import Item.Model exposing (ItemId, Item)
 import User.Model exposing (User)
 
 
-view : Date -> User -> ItemId -> Item -> Html Msg
-view currentDate currentUser itemId item =
+view : Date -> User -> ItemId -> Item -> Model -> Html Msg
+view currentDate currentUser itemId item model =
     div []
         [ div
             [ class "ui secondary pointing fluid menu" ]

--- a/client/src/elm/Pages/Item/View.elm
+++ b/client/src/elm/Pages/Item/View.elm
@@ -37,28 +37,25 @@ itemHeader : Item -> Model -> List (Html Msg)
 itemHeader item model =
     case model.editingItemName of
         Just editedName ->
-            [ div
-                [ class "ui header input" ]
-                [ h2 []
-                    [ input
-                        [ value editedName
-                        , onChange EditingNameUpdate
-                        ]
-                        []
+            [ h2 [ class "ui header input" ]
+                [ input
+                    [ value editedName
+                    , onChange EditingNameUpdate
                     ]
-                , button
-                    [ name "Done"
-                    , type_ "button"
-                    , onClick EditingNameFinish
-                    ]
-                    [ text "Done" ]
-                , button
-                    [ name "Cancel"
-                    , type_ "button"
-                    , onClick EditingNameCancel
-                    ]
-                    [ text "Cancel" ]
+                    []
                 ]
+            , button
+                [ name "Done"
+                , type_ "button"
+                , onClick EditingNameFinish
+                ]
+                [ text "Done" ]
+            , button
+                [ name "Cancel"
+                , type_ "button"
+                , onClick EditingNameCancel
+                ]
+                [ text "Cancel" ]
             ]
 
         Nothing ->
@@ -66,10 +63,11 @@ itemHeader item model =
                 [ class "ui header" ]
                 [ text item.name ]
             , button
-                [ onClick EditingNameBegin
-                , class "icon edit"
+                [ name "Edit"
+                , type_ "button"
+                , onClick EditingNameBegin
                 ]
-                []
+                [ text "Edit" ]
             ]
 
 


### PR DESCRIPTION
This modifies the item page with an "Edit" button allowing you to edit the name of the displayed item, along with a "Cancel" button to restore the previous name and a "Done" button to finalize the change and update the item on the backend.

Demonstration:

![drupal-elm-starter edit-item-name](https://cloud.githubusercontent.com/assets/1911496/26057984/3a6d7280-3952-11e7-9268-75fbe722e3a4.gif)

TODO:

- Tests. (I'm not yet familiar with webdriver-io/selenium.)

- Css. The buttons are rather ugly.