### PR TITLE
README: better local CI test instructions

### DIFF
--- a/ci-scripts/README.md
+++ b/ci-scripts/README.md
@@ -3,12 +3,13 @@
 ## Test CI execution on local
 1. `cd <repository_root>`
 2. `docker build -t server -f ci-scripts/docker_files/Dockerfile .`
-3. Client: `docker run -it -p 8080:80 -e BUILD_CLIENT=1 server`
+3. Client: `mkdir /tmp/travis-cache && docker run -v /tmp/travis-cache:/tmp/travis-cache -it -p 8080:80 -e BUILD_CLIENT=1 server`
 4. Server: `cd ci-scripts/docker_files && export BUILD_WEBDRIVERIO=1 && docker-compose up`
 
 ## Debug CI execution
 
 Apart from simply executing the same what Travis executes, you have the ability to inspect the container interactively after rthe execution if you start your container with an extra environment variable:
 ```
-docker run -it -p 8080:80 -e BUILD_WEBDRIVERIO=1 -e DOCKER_DEBUG=1 server
+mkdir /tmp/travis-cache
+docker run -v /tmp/travis-cache:/tmp/travis-cache -it -p 8080:80 -e BUILD_WEBDRIVERIO=1 -e DOCKER_DEBUG=1 server
 ```


### PR DESCRIPTION
After the merge of https://github.com/Gizra/drupal-elm-starter/pull/105, the README became outdated, this is going to fix it.