### PR TITLE
Lock Zalenium version

### DIFF
--- a/ci-scripts/docker_files/docker-compose.yml
+++ b/ci-scripts/docker_files/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
     hub:
         privileged: true
-        image: dosel/zalenium
+        image: dosel/zalenium:3.3.1j
         tty: true
         command: >
           start --chromeContainers 1


### PR DESCRIPTION
## Status

Lock Zalenium to the current latest version to avoid breaking Travis with upcoming more releases.
It happened twice already that our builds became broken, and even now that it has tests, backward-incompatible changes could happen anytime.

@amitaibu do you agree with the principle or should we invest time on following that docker image and adapting continuously?

#114 