### PR TITLE
entity_validator: freeze the version

### DIFF
--- a/server/hedley/drupal-org.make
+++ b/server/hedley/drupal-org.make
@@ -38,7 +38,7 @@ projects[entityreference][subdir] = "contrib"
 projects[entityreference][version] = "1.2"
 
 projects[entity_validator][subdir] = "contrib"
-projects[entity_validator][version] = "1.x"
+projects[entity_validator][version] = "1.2"
 
 projects[facetapi][subdir] = "contrib"
 projects[facetapi][version] = "1.5"


### PR DESCRIPTION
https://www.drupal.org/project/entity_validator/releases/7.x-1.2

to avoid potential incompatible changes in the future