### PR TITLE
Drop Dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,0 @@
-client/node_modules
-client/serve
-client/dist
-client/elm-stuff
-client/bower_components
-server/www


### PR DESCRIPTION
As we use Travis-native execution, it became obsolete