### PR TITLE
Selenium standalone - update to latest stable

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -39,7 +39,7 @@
     "merge-stream": "0.1.8",
     "wdio-browserstack-service": "0.1.4",
     "wdio-mocha-framework": "0.5.8",
-    "wdio-selenium-standalone-service": "0.0.9",
+    "wdio-selenium-standalone-service": "0.0.10",
     "wdio-spec-reporter": "0.0.5",
     "wiredep": "2.2.2"
   },


### PR DESCRIPTION
#185 

## Status

applied https://github.com/webdriverio/wdio-selenium-standalone-service/releases/tag/v0.0.10 in order to be compatible with latest Chrome